### PR TITLE
Fix url parameter will be cache in github action

### DIFF
--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -35,7 +35,7 @@ jobs:
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
-          target_branch: monkeytype-readme
+          target_branch: monkeytype-readme-workflow-svg
           build_dir: monkeytype-readme-workflow-svg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -33,7 +33,7 @@ jobs:
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
-          target_branch: monkeytype-readme-svg
-          build_dir: monkeytype-readme
+          target_branch: monkeytype-readme
+          build_dir: monkeytype-readme-svg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -1,10 +1,8 @@
 name: generate monkeytype readme svg
 
 on:
-  push:
-    branches: [monkeytype-readme-workflow]
-#   schedule:
-#     - cron: "0 */12 * * *"
+  schedule:
+    - cron: "0 */12 * * *"
   workflow_dispatch:
 
 jobs:
@@ -21,21 +19,21 @@ jobs:
 
       - name: Download SVG
         run: |
-          mkdir monkeytype-readme-workflow-svg
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lbpb=true
+          mkdir monkeytype-readme-svg
+          curl -o monkeytype-readme-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
+          curl -o monkeytype-readme-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
+          curl -o monkeytype-readme-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
+          curl -o monkeytype-readme-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lbpb=true
           
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lbpb=true
+          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
+          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true
+          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?pb=true
+          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lbpb=true
 
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
-          target_branch: monkeytype-readme-workflow-svg
-          build_dir: monkeytype-readme-workflow-svg
+          target_branch: monkeytype-readme-svg
+          build_dir: monkeytype-readme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -25,12 +25,12 @@ jobs:
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?timestamp=${{ github.run_id }}&lb=true&pb=true
           
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&lb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&lb=true&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?timestamp=${{ github.run_id }}&lb=true&pb=true
 
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0

--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -25,12 +25,12 @@ jobs:
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?timestamp=${{ github.run_id }}&lb=true&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lbpb=true
           
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true
           curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?pb=true
-          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?timestamp=${{ github.run_id }}&lb=true&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lbpb=true
 
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0

--- a/.github/workflows/monkeytype-readme.yml
+++ b/.github/workflows/monkeytype-readme.yml
@@ -1,8 +1,10 @@
 name: generate monkeytype readme svg
 
 on:
-  schedule:
-    - cron: "0 */12 * * *"
+  push:
+    branches: [monkeytype-readme-workflow]
+#   schedule:
+#     - cron: "0 */12 * * *"
   workflow_dispatch:
 
 jobs:
@@ -19,21 +21,21 @@ jobs:
 
       - name: Download SVG
         run: |
-          mkdir monkeytype-readme-svg
-          curl -o monkeytype-readme-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
-          curl -o monkeytype-readme-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
-          curl -o monkeytype-readme-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
-          curl -o monkeytype-readme-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true&pb=true
+          mkdir monkeytype-readme-workflow-svg
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/rocket/botanical?lb=true&pb=true
           
-          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
-          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true
-          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?pb=true
-          curl -o monkeytype-readme-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&lb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&pb=true
+          curl -o monkeytype-readme-workflow-svg/monkeytype-readme-Miodec-lb-pb.svg https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?$(date +%s)&lb=true&pb=true
 
       - name: push monkeytype-readme.svg to the monkeytype-readme branch
         uses: crazy-max/ghaction-github-pages@v2.5.0
         with:
           target_branch: monkeytype-readme
-          build_dir: monkeytype-readme-svg
+          build_dir: monkeytype-readme-workflow-svg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app.js
+++ b/app.js
@@ -18,8 +18,9 @@ app.get('/', (req, res) => {
 app.get('/generate-svg/:userId/:themeName', async (req, res) => {
     const userId = req.params.userId;
     const themeName = req.params.themeName;
-    const leaderBoards = req.query.lb == "true" ? true : false;
-    const personalBests = req.query.pb == "true" ? true : false;
+    let leaderBoards = req.query.lb == "true" ? true : false;
+    let personalBests = req.query.pb == "true" ? true : false;
+    req.query.lbpb == "true" ? leaderBoards = personalBests = true : null;
     const userData = await getUserData(userId);
     if (userData === undefined) {
         res.send("User not found");


### PR DESCRIPTION
When getting MonkeyType Readme SVG with leader board and personal boards the url `https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true&pb=true` will cause by cache problem get leader board SVG `https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lb=true`, so add a new parameter in url for SVG with leader board and personal board `https://monkeytype-readme.repl.co/generate-svg/Miodec/nord_light?lbpb=true`.